### PR TITLE
[de]: Add Repository to exclude.json

### DIFF
--- a/locales/de/_excludes.json
+++ b/locales/de/_excludes.json
@@ -1,5 +1,6 @@
 [
     "Dashboard",
     "Name",
+    "Repository",
     "System"
 ]


### PR DESCRIPTION
"Repository" here is a link to the github repository of the starter kit. 

a possible translation would be Projektarchiv, but the common name in German for a repo is indeed Repository as well

German Wikipedia article about a [software repo](https://en.wikipedia.org/wiki/Software_repository) is called [Repository](https://de.wikipedia.org/wiki/Repository)

