### PR TITLE
[es]: Fix translation

### DIFF
--- a/locales/es/json.json
+++ b/locales/es/json.json
@@ -6,7 +6,7 @@
     "Accept invitation": "Aceptar invitación",
     "Add a passkey to sign in without a password": "Agregue una llave de acceso para iniciar sesión sin contraseña",
     "Add passkey": "Agregar llave de acceso",
-    "Added :time": "Agregado :time",
+    "Added :time": "Agregada :time",
     "Already have an account?": "¿Ya tiene una cuenta?",
     "An invitation has already been sent to this email address.": "Ya se ha enviado una invitación a esta dirección de correo electrónico.",
     "Appearance": "Apariencia",


### PR DESCRIPTION
Passkeys in spanish belongs to female gender